### PR TITLE
Add sub-query user info similarity metric

### DIFF
--- a/ragas/src/ragas/dataset_schema.py
+++ b/ragas/src/ragas/dataset_schema.py
@@ -80,6 +80,8 @@ class SingleTurnSample(BaseSample):
         The generated response for the query.
     multi_responses : Optional[List[str]]
         List of multiple responses generated for the query.
+    user_profile : Optional[str]
+        The personal information or user portrait associated with the query.
     reference : Optional[str]
         The reference answer for the query.
     rubric : Optional[Dict[str, str]]
@@ -91,6 +93,7 @@ class SingleTurnSample(BaseSample):
     reference_contexts: t.Optional[t.List[str]] = None
     response: t.Optional[str] = None
     multi_responses: t.Optional[t.List[str]] = None
+    user_profile: t.Optional[str] = None
     reference: t.Optional[str] = None
     rubrics: t.Optional[t.Dict[str, str]] = None
 

--- a/ragas/src/ragas/metrics/__init__.py
+++ b/ragas/src/ragas/metrics/__init__.py
@@ -65,6 +65,10 @@ from ragas.metrics._sub_query_coverage import (
     SubQueryCoverage,
     sub_query_semantic_coverage,
 )
+from ragas.metrics._sub_query_user_info_similarity import (
+    SubQueryUserInfoSimilarity,
+    sub_query_user_info_similarity,
+)
 from ragas.metrics._summarization import SummarizationScore, summarization_score
 from ragas.metrics._tool_call_accuracy import ToolCallAccuracy
 from ragas.metrics._topic_adherence import TopicAdherenceScore
@@ -142,4 +146,6 @@ __all__ = [
     "multimodal_relevance",
     "SubQueryCoverage",
     "sub_query_semantic_coverage",
+    "SubQueryUserInfoSimilarity",
+    "sub_query_user_info_similarity",
 ]

--- a/ragas/src/ragas/metrics/_sub_query_user_info_similarity.py
+++ b/ragas/src/ragas/metrics/_sub_query_user_info_similarity.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import typing as t
+from dataclasses import dataclass, field
+
+import numpy as np
+
+from ragas.dataset_schema import SingleTurnSample
+from ragas.metrics.base import (
+    MetricOutputType,
+    MetricType,
+    MetricWithEmbeddings,
+    SingleTurnMetric,
+)
+
+if t.TYPE_CHECKING:
+    from langchain_core.callbacks import Callbacks
+
+
+@dataclass
+class SubQueryUserInfoSimilarity(MetricWithEmbeddings, SingleTurnMetric):
+    """Semantic similarity between sub-queries and the original query with user profile."""
+
+    name: str = "sub_query_user_info_similarity"
+    _required_columns: t.Dict[MetricType, t.Set[str]] = field(
+        default_factory=lambda: {
+            MetricType.SINGLE_TURN: {"user_input", "reference_contexts", "user_profile"}
+        }
+    )
+    output_type = MetricOutputType.CONTINUOUS
+
+    async def _single_turn_ascore(
+        self, sample: SingleTurnSample, callbacks: Callbacks
+    ) -> float:
+        row = sample.to_dict()
+        return await self._ascore(row, callbacks)
+
+    async def _ascore(self, row: t.Dict, callbacks: Callbacks) -> float:
+        assert self.embeddings is not None, "Embeddings must be set"
+
+        query: str = row["user_input"]
+        sub_queries: t.Sequence[str] = row["reference_contexts"]
+        user_profile: str = row.get("user_profile", "") or ""
+
+        combined = f"{user_profile} {query}".strip()
+
+        base_emb = np.asarray(await self.embeddings.embed_text(combined))
+        sub_embs = np.asarray(await self.embeddings.embed_documents(list(sub_queries)))
+
+        base_norm = np.linalg.norm(base_emb)
+        sub_norms = np.linalg.norm(sub_embs, axis=1)
+        similarities = (sub_embs @ base_emb) / (sub_norms * base_norm + 1e-8)
+        return float(np.mean(similarities))
+
+
+sub_query_user_info_similarity = SubQueryUserInfoSimilarity()


### PR DESCRIPTION
## Summary
- add `user_profile` field to SingleTurnSample
- implement `SubQueryUserInfoSimilarity` metric to score similarity of sub-queries with user profile and query
- expose new metric in metrics package

## Testing
- `ruff check ragas/src ragas/tests`
- `pyright ragas/src/ragas` *(failed: Import errors)*
- `pytest -q` *(failed: ModuleNotFoundError: numpy)*

------
https://chatgpt.com/codex/tasks/task_e_684fd6c16bfc8320a1f59d466b65e598