### PR TITLE
Add semantic and personalized evaluation metrics

### DIFF
--- a/ragas/src/ragas/metrics/__init__.py
+++ b/ragas/src/ragas/metrics/__init__.py
@@ -53,10 +53,15 @@ from ragas.metrics._nv_metrics import (
     ResponseGroundedness,
 )
 from ragas.metrics._personalized_metrics import (
+    FormatConsistencyScore,
+    KnowledgeConflictAccuracy,
     PersonalizedRetrievalNDCG,
     PersonalizedRetrievalRecall,
     QueryDocPersonalizedRelevance,
     QueryDocSemanticRelevance,
+    QueryResponseSemanticCoverage,
+    QueryResponseSemanticRelevance,
+    StyleConsistencyScore,
 )
 from ragas.metrics._rouge_score import RougeScore
 from ragas.metrics._simple_criteria import SimpleCriteriaScore
@@ -156,6 +161,11 @@ __all__ = [
     "sub_query_user_info_similarity",
     "PersonalizedRetrievalNDCG",
     "PersonalizedRetrievalRecall",
+    "QueryResponseSemanticRelevance",
+    "QueryResponseSemanticCoverage",
+    "StyleConsistencyScore",
+    "FormatConsistencyScore",
+    "KnowledgeConflictAccuracy",
     "QueryDocSemanticRelevance",
     "QueryDocPersonalizedRelevance",
 ]


### PR DESCRIPTION
## Summary
- implement semantic and personalized metrics
- expose new metrics in package

## Testing
- `make format`
- `make lint` *(fails: F821 in docs)*
- `ruff check ragas/src ragas/tests`
- `make type` *(fails: could not fetch pyright)*
- `make test` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684fe0c9632c8320837fe5afd883bb19