### PR TITLE
Add multi-round retrieval metrics docs

### DIFF
--- a/docs/concepts/metrics/available_metrics/index.md
+++ b/docs/concepts/metrics/available_metrics/index.md
@@ -9,6 +9,8 @@ Each metric are essentially paradigms that are designed to evaluate a particular
 - [Context Recall](context_recall.md)
 - [Context Entities Recall](context_entities_recall.md)
 - [Noise Sensitivity](noise_sensitivity.md)
+- [Cumulative Retrieval](multi_round_retrieval.md#cumulative-retrieval)
+- [Multi-round Information Gain](multi_round_retrieval.md#multi-round-information-gain)
 - [Response Relevancy](answer_relevance.md)
 - [Faithfulness](faithfulness.md)
 - [Multimodal Faithfulness](multi_modal_faithfulness.md)

--- a/docs/concepts/metrics/available_metrics/multi_round_retrieval.md
+++ b/docs/concepts/metrics/available_metrics/multi_round_retrieval.md
@@ -1,0 +1,18 @@
+# Multi-round Retrieval Metrics
+
+Evaluating retrieval over multiple rounds can reveal how quickly a system gathers the information required to answer a query. The following metrics help analyze convergence.
+
+## Cumulative Retrieval
+
+At round $t$, this metric computes recall on the union of retrieved results from all rounds so far.
+
+$$
+C_t = \operatorname{Recall}(D_1 \cup D_2 \cup \dots \cup D_t)
+$$
+
+Where $D_i$ denotes the set of documents retrieved in round $i$. Plotting $C_t$ against $t$ shows whether additional retrieval rounds continue to uncover new relevant information.
+
+## Multi-round Information Gain
+
+To measure the value of each round, evaluate the semantic coverage of the generated answer after incorporating the most recent context. The [`QueryResponseSemanticCoverage`](../../../../ragas/src/ragas/metrics/_personalized_metrics.py) metric can be used for this purpose. Tracking this score across rounds highlights diminishing returns as coverage approaches saturation.
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,6 +33,8 @@ nav:
                   - Context Recall: concepts/metrics/available_metrics/context_recall.md
                   - Context Entities Recall: concepts/metrics/available_metrics/context_entities_recall.md
                   - Noise Sensitivity: concepts/metrics/available_metrics/noise_sensitivity.md
+                  - Cumulative Retrieval: concepts/metrics/available_metrics/multi_round_retrieval.md#cumulative-retrieval
+                  - Multi-round Information Gain: concepts/metrics/available_metrics/multi_round_retrieval.md#multi-round-information-gain
                   - Response Relevancy: concepts/metrics/available_metrics/answer_relevance.md
                   - Faithfulness: concepts/metrics/available_metrics/faithfulness.md
               - Nvidia Metrics:


### PR DESCRIPTION
## Summary
- document cumulative retrieval and multi-round information gain metrics
- list the new metrics in the metrics index and site navigation

## Testing
- `make format`

------
https://chatgpt.com/codex/tasks/task_e_684fe2d340bc8320b0ed8b63b68c2a1c